### PR TITLE
Fix access rules for Cheese Bridge secret exit

### DIFF
--- a/super_mario_world_randomizer_porygone/locations/cheese_bridge_area.json
+++ b/super_mario_world_randomizer_porygone/locations/cheese_bridge_area.json
@@ -41,8 +41,8 @@
                         ],
                         "name": "Secret Exit",
                         "access_rules": [
-                            "powerup_3, run",
-                            "[powerup_3], yoshi"
+                            "run, powerup_3",
+                            "run, yoshi"
                         ],
                         "chest_unopened_img": "images/checks/goal_sphere_disabled.png",
                         "chest_opened_img": "images/checks/goal_sphere.png",


### PR DESCRIPTION
The access rules in the poptracker pack are different from the Archipelago world access rules as of AP commit f8d5fe0.

cf: https://github.com/ArchipelagoMW/Archipelago/blob/2a11d610b6d18df9e226719e9c14ab34dddacc27/worlds/smw/Regions.py#L1941

```py
connect(world, LocationName.cheese_bridge_region, LocationName.cheese_bridge_exit_2,
        lambda state: (state.has(ItemName.mario_run, player) and
                       (state.has(ItemName.progressive_powerup, player, 3) or
                       state.has(ItemName.yoshi_activate, player))))
```

I'm not super familar with SMW logic though -- maybe the second rule for the poptracker pack was supposed to be "[run], yoshi"? But either way, run+yoshi should be in-logic without needing cape.